### PR TITLE
Fix ocgo README typo

### DIFF
--- a/scripts/ocgo/README.md
+++ b/scripts/ocgo/README.md
@@ -22,7 +22,7 @@ own preferred nameserver: `./reset_dns.sh 8.8.8.8`
 
 Then you can save the entire command as an alias by adding the following to your `~/.bashrc` or `~/.zshrc`:
 `alias vpn='cd path_to_ocgo && ./ocgo || ./reset_dns.sh'`
-where `patch_to_ocgo` is the path to the place where you downloaded `ocgo` and `reset_dns.sh`
+where `path_to_ocgo` is the path to the place where you downloaded `ocgo` and `reset_dns.sh`
 
 ## Operation
 


### PR DESCRIPTION
## Summary
- fix patch_to_ocgo -> path_to_ocgo in ocgo README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f81167de0832295513ae8cac64eb8