### PR TITLE
Fix ocgo build path

### DIFF
--- a/scripts/ocgo/build.sh
+++ b/scripts/ocgo/build.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 # Check for changes in the specified directory
-if git diff --name-only "$BITBUCKET_COMMIT_RANGE" | grep -q "^script/ocgo/"; then
-    echo "Changes detected in script/ocgo/, proceeding with build..."
+if git diff --name-only "$BITBUCKET_COMMIT_RANGE" | grep -q "^scripts/ocgo/"; then
+    echo "Changes detected in scripts/ocgo/, proceeding with build..."
     # Build the package
     cd scripts/ocgo || exit
     go build -o ocgo main.go
 else
-    echo "No changes in script/ocgo/, skipping build step."
+    echo "No changes in scripts/ocgo/, skipping build step."
 fi


### PR DESCRIPTION
## Summary
- ensure the build script looks at `scripts/ocgo` rather than `script/ocgo`

## Testing
- `gofmt -w main.go`
- `go build -o ocgo main.go` *(fails: Forbidden)*
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684f811bc4f4832298da4098193fa156